### PR TITLE
Support optional chaining in composition rule

### DIFF
--- a/source/rules/prefer-composition.ts
+++ b/source/rules/prefer-composition.ts
@@ -198,9 +198,16 @@ const rule = ruleCreator({
       // subscription or if it's assigned to a variable that is added to a
       // subscription.
       const { addCallExpressions, subscriptions } = entry;
-      const parent = getParent(callExpression);
+      let parent = getParent(callExpression);
       if (!parent) {
         return false;
+      }
+      // Handle optional chaining.
+      if (parent.type === "ChainExpression") {
+        parent = getParent(parent);
+        if (!parent) {
+          return false;
+        }
       }
       if (isCallExpression(parent)) {
         const addCallExpression = addCallExpressions.find(

--- a/tests/rules/prefer-composition.ts
+++ b/tests/rules/prefer-composition.ts
@@ -98,6 +98,35 @@ ruleTester({ types: true }).run("prefer-composition", rule, {
         }
       `,
     },
+    {
+      code: stripIndent`
+      // optional chaining should work
+      import { Component, OnDestroy, OnInit } from '@angular/core';
+      import { Observable, Subscription } from 'rxjs';
+
+      class SomeThing {
+        obs: Observable<string> = of('foo');
+      }
+
+      @Component({
+        selector: 'optional-chaining-component',
+        template: '<span>{{ value }}</span>',
+      })
+      export class VariableComposedComponent implements OnInit, OnDestroy {
+        value: string;
+        private subscription = new Subscription();
+        ngOnInit() {
+          let st: SomeThing | undefined;
+          let s = st?.obs.subscribe((value) => (this.value = value));
+          this.subscription.add(s);
+          this.subscription.add(st?.obs.subscribe((value) => (this.value = value)));
+        }
+        ngOnDestroy() {
+          this.subscription.unsubscribe();
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     fromFixture(


### PR DESCRIPTION
Prior to this PR, if a subscription was called in a `ChainExpression` (created by using the optional chaining operator `?`) it would report a composition error. 

```typescript
ngOnInit() {
  let st: SomeThing | undefined;
  let s = st?.obs.subscribe((value) => (this.value = value)); // CompositionError here
  this.subscription.add(s);
  this.subscription.add(st?.obs.subscribe((value) => (this.value = value)));
}
```

This PR adds support for optional chaining.