### PR TITLE
Update package.json to point to NPM registry instead of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 # eslint-plugin-rxjs-angular
 
-[![GitHub License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/cartant/eslint-plugin-rxjs-angular/blob/master/LICENSE)
-[![NPM version](https://img.shields.io/npm/v/eslint-plugin-rxjs-angular.svg)](https://www.npmjs.com/package/eslint-plugin-rxjs-angular)
-[![Downloads](http://img.shields.io/npm/dm/eslint-plugin-rxjs-angular.svg)](https://npmjs.org/package/eslint-plugin-rxjs-angular)
-[![Build status](https://img.shields.io/circleci/build/github/cartant/eslint-plugin-rxjs-angular?token=d3e3fd6613244558287da156fd9e0c4357a2170c)](https://app.circleci.com/pipelines/github/cartant)
-[![dependency status](https://img.shields.io/david/cartant/eslint-plugin-rxjs-angular.svg)](https://david-dm.org/cartant/eslint-plugin-rxjs-angular)
-[![devDependency Status](https://img.shields.io/david/dev/cartant/eslint-plugin-rxjs-angular.svg)](https://david-dm.org/cartant/eslint-plugin-rxjs-angular#info=devDependencies)
-[![peerDependency Status](https://img.shields.io/david/peer/cartant/eslint-plugin-rxjs-angular.svg)](https://david-dm.org/cartant/eslint-plugin-rxjs-angular#info=peerDependencies)
-
 This package contains ESLint versions of the Angular/RxJS rules that are in the [`rxjs-tslint-rules`](https://github.com/cartant/rxjs-tslint-rules) package.
 
 There is no recommended configuration for this package, as all of the rules are opinionated.
@@ -23,7 +15,7 @@ npm install @typescript-eslint/parser --save-dev
 Install the package using npm:
 
 ```
-npm install eslint-plugin-rxjs-angular --save-dev
+npm install @smartpassk12/eslint-plugin-rxjs-angular --save-dev
 ```
 
 Configure the `parser` and the `parserOptions` for ESLint. Here, I use a `.eslintrc.js` file for the configuration:
@@ -54,3 +46,10 @@ The package includes the following rules:
 | [`prefer-async-pipe`](https://github.com/cartant/eslint-plugin-rxjs-angular/blob/main/docs/rules/prefer-async-pipe.md) | Forbids the calling of `subscribe` within Angular components. | No |
 | [`prefer-composition`](https://github.com/cartant/eslint-plugin-rxjs-angular/blob/main/docs/rules/prefer-composition.md) | Forbids `subscribe` calls that are not composed within Angular components (and, optionally, within services, directives, and pipes). | No |
 | [`prefer-takeuntil`](https://github.com/cartant/eslint-plugin-rxjs-angular/blob/main/docs/rules/prefer-takeuntil.md) | Forbids Calling `subscribe` without an accompanying `takeUntil`. | No |
+
+# Publishing
+
+To publish a new version of the package, run locally:
+```
+yarn publish --access public
+```

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "*.{js,ts}": "prettier --write"
   },
   "main": "./dist/index.js",
-  "name": "@smartpass/eslint-plugin-rxjs-angular",
+  "name": "@smartpassk12/eslint-plugin-rxjs-angular",
   "optionalDependencies": {},
   "peerDependencies": {
     "eslint": "^8.0.0",
@@ -54,8 +54,7 @@
   },
   "private": false,
   "publishConfig": {
-    "tag": "latest",
-    "registry": "https://npm.pkg.github.com"
+    "tag": "latest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates the package.json to point to the NPM registry. I attempted to use the GitHub package registry, but this requires special `.yarnrc` configuration in the project as well as authenticating against the registry. Anonymous users are not supported for GitHub Registry. 

We now have our own NPM scope: `@smartpassk12`. `@smartpass` was taken :(

You can publish a new version of this package by following the instructions in the README. 